### PR TITLE
Allow >=4.2 versions of illuminate/support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "require":     {
         "cache/cache":              "^0.1",
         "guzzlehttp/guzzle":        "~5.3|~6.0",
-        "illuminate/support":       "^5.1",
+        "illuminate/support":       ">=4.2 <6",
         "nesbot/carbon":            "^1.21",
         "ratchet/pawl":             "0.2.*",
         "react/datagram":           "1.1.*",


### PR DESCRIPTION
I've sifted through DiscordPHPs files where Illuminate\Support is used and there shouldn't be any reason to run `^5.1`.

As far as I can tell there is no breakage, but I'm expecting Travis to have my back in case I'm wrong.