### PR TITLE
Support for projects with Illuminate/Support 4.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "require":     {
         "cache/cache":              "^0.1",
         "guzzlehttp/guzzle":        "~5.3|~6.0",
-        "illuminate/support":       ">=4.2 <6",
+        "illuminate/support":       "^4.0|^5.0",
         "nesbot/carbon":            "^1.21",
         "ratchet/pawl":             "0.2.*",
         "react/datagram":           "1.1.*",

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "require":     {
         "cache/cache":              "^0.1",
         "guzzlehttp/guzzle":        "~5.3|~6.0",
-        "illuminate/support":       "^5.1",
+        "illuminate/support":       ">=4.2 <6",
         "nesbot/carbon":            "^1.21",
         "ratchet/pawl":             "0.2.*",
         "react/datagram":           "1.1.*",


### PR DESCRIPTION
Followup on [#102 - Allow >=4.2 versions of illuminate/support](https://github.com/teamreflex/DiscordPHP/pull/102)