### PR TITLE
Hide the token while debugging

### DIFF
--- a/src/Discord/Discord.php
+++ b/src/Discord/Discord.php
@@ -1353,6 +1353,8 @@ class Discord
         $replace = array_intersect_key($secrets, $this->options);
         $config = $replace + $this->options;
 
+        unset($config['loop'], $config['cachePool'], $config['logger']);
+
         return $config;
     }
 }

--- a/src/Discord/Discord.php
+++ b/src/Discord/Discord.php
@@ -1338,4 +1338,21 @@ class Discord
 
         return call_user_func_array([$this->client, $name], $params);
     }
+
+    /**
+     * Returns an array that can be used to describe the internal state of this
+     * object.
+     *
+     * @return array
+     */
+    public function __debugInfo()
+    {
+        $secrets = [
+            'token' => '*****'
+        ];
+        $replace = array_intersect_key($secrets, $this->options);
+        $config = $replace + $this->options;
+
+        return $config;
+    }
 }

--- a/src/Discord/Discord.php
+++ b/src/Discord/Discord.php
@@ -1348,10 +1348,10 @@ class Discord
     public function __debugInfo()
     {
         $secrets = [
-            'token' => '*****'
+            'token' => '*****',
         ];
         $replace = array_intersect_key($secrets, $this->options);
-        $config = $replace + $this->options;
+        $config  = $replace + $this->options;
 
         unset($config['loop'], $config['cachePool'], $config['logger']);
 


### PR DESCRIPTION
This is done to protect the token credentials, which could be accidentally shown in the console.