### PR TITLE
Updated requirements to fix Timestamp error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /vendor
 composer.lock
 test*.php
+.idea

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
   ],
   "require": {
     "php": "^5.6|^7.0",
-    "cache/array-adapter": "^0.4.0",
+    "cache/array-adapter": "^0.4.2",
     "guzzlehttp/guzzle": "~5.3|~6.0",
     "illuminate/support": "^4.0|^5.0",
     "nesbot/carbon": "^1.18",


### PR DESCRIPTION
The following error should be fixed now with the update of the requirements:

```PHP Warning:  DateTime::createFromFormat(): It is not safe to rely on the system's timezone settings. You are *required* to use the date.timezone setting or the date_default_timezone_set() function. In case you used any of those methods and you are still getting this warning, you most likely misspelled the timezone identifier. We selected the timezone 'UTC' for now, but please set date.timezone to select your timezone. in /Users/jpache/DEV/web/php-discordbot/src/lib/cache/adapter-common/CacheItem.php on line 157```