### PR TITLE
Mitigate missing members and roles for guild

### DIFF
--- a/src/Discord/Parts/Channel/Message.php
+++ b/src/Discord/Parts/Channel/Message.php
@@ -206,7 +206,7 @@ class Message extends Part
     {
         return $this->channel->sendMessage("{$this->author}, {$text}");
     }
-    
+
     /**
      * Send message after delay.
      *
@@ -318,7 +318,7 @@ class Message extends Part
 
     /**
      * Creates a reaction collector for the message.
-     * 
+     *
      * @param callable $filter The filter function. Returns true or false.
      * @param int      $options['time']  Time in milliseconds until the collector finishes or false.
      * @param int      $options['limit'] The amount of reactions allowed or false.
@@ -400,6 +400,10 @@ class Message extends Part
     {
         $roles = new Collection([], 'id');
 
+        if(!isset($this->channel->guild->roles)) {
+            return $roles;
+        }
+
         foreach ($this->channel->guild->roles as $role) {
             if (array_search($role->id, $this->attributes['mention_roles']) !== false) {
                 $roles->push($role);
@@ -432,7 +436,13 @@ class Message extends Part
      */
     public function getAuthorAttribute()
     {
-        if ($this->channel->type != Channel::TYPE_TEXT && $author = $this->channel->guild->members->get('id', $this->attributes['author']->id)) {
+        if (
+            $this->channel->type != Channel::TYPE_TEXT &&
+            (
+                isset($this->channel->guild->members) and
+                $author = $this->channel->guild->members->get('id', $this->attributes['author']->id)
+            )
+        ) {
             return $author;
         }
 
@@ -481,9 +491,9 @@ class Message extends Part
 
     /**
      * Adds an embed to the message.
-     * 
+     *
      * @param Embed $embed
-     * 
+     *
      * @return \React\Promise\Promise
      */
     public function addEmbed(Embed $embed)


### PR DESCRIPTION
Fix for when both roles and members are disabled.
This issue happens when sending a message via a private channel.

Thanks for the great work on the bot!