### PR TITLE
Update Event::VoiceStateUpdate / Add Channel::editMessage

### DIFF
--- a/src/Discord/Parts/Channel/Channel.php
+++ b/src/Discord/Parts/Channel/Channel.php
@@ -703,6 +703,45 @@ class Channel extends Part
     }
 
     /**
+     * Edit a message in the channel.
+     *
+     * @param Message $message  The message to edit.
+     * @param string  $text     The text to of the message.
+     * @param bool    $tts      Whether the message should be sent with text to speech enabled.
+     * @param Embed|array|null $embed An embed to send.
+     *
+     * @return PromiseInterface
+     * @throws \Exception
+     */
+    public function editMessage(Message $message, string $text, bool $tts = false, $embed = null): PromiseInterface
+    {
+        if ($embed instanceof Embed) {
+            $embed = $embed->getRawAttributes();
+        }
+        $deferred = new Deferred();
+
+        $this->http->patch(
+            "channels/{$this->id}/messages/{$message->id}",
+            [
+                'content' => $text,
+                'tts' => $tts,
+                'embed' => $embed,
+            ]
+        )->then(
+            function ($response) use ($deferred) {
+                $message = $this->factory->create(Message::class, (array) $response, true);
+                $this->messages->push($message);
+
+                $deferred->resolve($message);
+            },
+            Bind([$deferred, 'reject'])
+        );
+
+        return $deferred->promise();
+    }
+
+
+    /**
      * Sends an embed to the channel if it is a text channel.
      *
      * @param Embed $embed

--- a/src/Discord/WebSockets/Events/VoiceStateUpdate.php
+++ b/src/Discord/WebSockets/Events/VoiceStateUpdate.php
@@ -28,24 +28,20 @@ class VoiceStateUpdate extends Event
         if ($state->guild) {
             $guild = $state->guild;
 
-            // Remove old member states
             foreach ($guild->channels as $channel) {
-                if ($channel->getChannelType() !== Channel::TYPE_VOICE) {
+                if (! $channel->allowVoice()) {
                     continue;
                 }
 
-                foreach ($channel->members as $member) {
-                    if ($member->user_id == $state->user_id) {
-                        $channel->members->pull($member->user_id);
-                    }
+                // Remove old member states
+                if ($channel->members->has($state->user_id)) {
+                    $channel->members->pull($state->user_id);
                 }
 
-                $guild->channels->push($channel);
-            }
-
-            // Add member state to new channel
-            if ($state->channel_id && $channel = $guild->channels->get('id', $state->channel_id)) {
-                $channel->members->push($state);
+                // Add member state to new channel
+                if ($channel->id == $state->channel_id) {
+                    $channel->members->push($state);
+                }
 
                 $guild->channels->push($channel);
             }


### PR DESCRIPTION
Event::VoiceStateUpdate:
- use allowVoice()
- get rid of the foreach and just check if it has() the member
- since we are looping through the channels anyways, why not push him here as well?

Channel::editMessage:
- because it's missing