### PR TITLE
More descriptive error outputs

### DIFF
--- a/src/Discord/Discord.php
+++ b/src/Discord/Discord.php
@@ -961,7 +961,7 @@ class Discord
             $this->emit('ready', [$this]);
         } catch (\Throwable $e) {
             $this->emit('exception', [$e, $this]);
-            $this->logger->error('exception caught in ready callback', ['type' => get_class($e), 'message' => $e->getMessage()]);
+            $this->logger->error('exception caught in ready callback', ['type' => get_class($e), 'message' => $e->getMessage() . " in file " . $e->getFile() . " on line " . $e->getLine()]);
         }
 
         foreach ($this->unparsedPackets as $parser) {


### PR DESCRIPTION
$e passes useful information that currently is not being taken advantage of. With this change
![image](https://user-images.githubusercontent.com/7202504/96803644-dc9ce480-13da-11eb-8bdc-feb788337808.png)
would become 
![image](https://user-images.githubusercontent.com/7202504/96803658-e45c8900-13da-11eb-9ef9-9ad43d27e43f.png)
