### PR TITLE
Cleanups, using the repositories and small updates

### DIFF
--- a/src/Discord/Discord.php
+++ b/src/Discord/Discord.php
@@ -384,7 +384,7 @@ class Discord
         $this->logger->debug('discord trace received', ['trace' => $content->_trace]);
 
         // Setup the user account
-        $this->client = $this->factory->create(Client::class, (array) $content->user, true);
+        $this->client = $this->factory->create(Client::class, $content->user, true);
         $this->sessionId = $content->session_id;
 
         $this->logger->debug('client created and session id stored', ['session_id' => $content->session_id, 'user' => $this->client->user->getPublicAttributes()]);
@@ -392,7 +392,7 @@ class Discord
         // Private Channels
         if ($this->options['pmChannels']) {
             foreach ($content->private_channels as $channel) {
-                $channelPart = $this->factory->create(Channel::class, (array) $channel, true);
+                $channelPart = $this->factory->create(Channel::class, $channel, true);
                 $this->private_channels->push($channelPart);
             }
 
@@ -479,7 +479,7 @@ class Discord
             $member['game'] = null;
 
             if (! $this->users->has($member['user']->id)) {
-                $userPart = $this->factory->create(User::class, (array) $member['user'], true);
+                $userPart = $this->factory->create(User::class, $member['user'], true);
                 $this->users->offsetSet($userPart->id, $userPart);
             }
 
@@ -1304,14 +1304,14 @@ class Discord
      * Allows access to the part/repository factory.
      *
      * @param string $class   The class to build.
-     * @param array  $data    Data to create the object.
+     * @param mixed  $data    Data to create the object.
      * @param bool   $created Whether the object is created (if part).
      *
      * @return Part|AbstractRepository
      *
      * @see Factory::create()
      */
-    public function factory(string $class, array $data = [], bool $created = false)
+    public function factory(string $class, $data = [], bool $created = false)
     {
         return $this->factory->create($class, $data, $created);
     }

--- a/src/Discord/Discord.php
+++ b/src/Discord/Discord.php
@@ -318,7 +318,7 @@ class Discord
         $function = function () use (&$function) {
             $this->emittedReady = true;
             $this->removeListener('ready', $function);
-        }
+        };
 
         $this->on('ready', $function);
 

--- a/src/Discord/Factory/Factory.php
+++ b/src/Discord/Factory/Factory.php
@@ -51,7 +51,7 @@ class Factory
      * Creates an object.
      *
      * @param string $class   The class to build.
-     * @param array  $data    Data to create the object.
+     * @param mixed  $data    Data to create the object.
      * @param bool   $created Whether the object is created (if part).
      *
      * @return Part|AbstractRepository The object.

--- a/src/Discord/Parts/Channel/Channel.php
+++ b/src/Discord/Parts/Channel/Channel.php
@@ -150,10 +150,10 @@ class Channel extends Part
 
         if (array_key_exists('recipients', $this->attributes)) {
             foreach ((array) $this->attributes['recipients'] as $recipient) {
-                if (! $user = $this->discord->users->get('id', $receipient->id)) {
+                if (! $user = $this->discord->users->get('id', $recipient->id)) {
                     $user = $this->factory->create(User::class, (array) $recipient, true);
                 }
-                $receipients->push($user);
+                $recipients->push($user);
             }
         }
 

--- a/src/Discord/Parts/Channel/Channel.php
+++ b/src/Discord/Parts/Channel/Channel.php
@@ -151,7 +151,7 @@ class Channel extends Part
         if (array_key_exists('recipients', $this->attributes)) {
             foreach ((array) $this->attributes['recipients'] as $recipient) {
                 if (! $user = $this->discord->users->get('id', $recipient->id)) {
-                    $user = $this->factory->create(User::class, (array) $recipient, true);
+                    $user = $this->factory->create(User::class, $recipient, true);
                 }
                 $recipients->push($user);
             }
@@ -200,7 +200,7 @@ class Channel extends Part
 
                 foreach ($responses as $response) {
                     if (! $message = $this->messages->get('id', $response->id)) {
-                        $message = $this->factory->create(Message::class, (array) $response, true);
+                        $message = $this->factory->create(Message::class, $response, true);
                     }
                     $messages->push($message);
                 }
@@ -433,7 +433,7 @@ class Channel extends Part
 
         $this->http->post($this->replaceWithVariables('channels/:id/invites'), $options)->then(
             function ($response) use ($deferred) {
-                $invite = $this->factory->create(Invite::class, (array) $response, true);
+                $invite = $this->factory->create(Invite::class, $response, true);
 
                 $deferred->resolve($invite);
             },
@@ -552,7 +552,7 @@ class Channel extends Part
 
                 foreach ($responses as $response) {
                     if (! $message = $this->messages->get('id', $response->id)) {
-                        $message = $this->factory->create(Message::class, (array) $response, true);
+                        $message = $this->factory->create(Message::class, $response, true);
                     }
                     $messages->push($message);
                 }
@@ -640,7 +640,7 @@ class Channel extends Part
                 $invites = new Collection();
 
                 foreach ($response as $invite) {
-                    $invite = $this->factory->create(Invite::class, (array) $invite, true);
+                    $invite = $this->factory->create(Invite::class, $invite, true);
                     $invites->push($invite);
                 }
 
@@ -703,7 +703,7 @@ class Channel extends Part
             ]
         )->then(
             function ($response) use ($deferred) {
-                $message = $this->factory->create(Message::class, (array) $response, true);
+                $message = $this->factory->create(Message::class, $response, true);
                 $this->messages->push($message);
 
                 $deferred->resolve($message);
@@ -741,7 +741,7 @@ class Channel extends Part
             ]
         )->then(
             function ($response) use ($deferred) {
-                $message = $this->factory->create(Message::class, (array) $response, true);
+                $message = $this->factory->create(Message::class, $response, true);
                 $this->messages->push($message);
 
                 $deferred->resolve($message);
@@ -772,7 +772,7 @@ class Channel extends Part
         }
 
         $this->http->post("channels/{$this->id}/messages", ['embed' => $embed->getRawAttributes()])->then(function ($response) use ($deferred) {
-            $message = $this->factory->create(Message::class, (array) $response, true);
+            $message = $this->factory->create(Message::class, $response, true);
             $this->messages->push($message);
 
             $deferred->resolve($message);
@@ -813,7 +813,7 @@ class Channel extends Part
 
         $this->http->sendFile($this, $filepath, $filename, $content, $tts)->then(
             function ($response) use ($deferred) {
-                $message = $this->factory->create(Message::class, (array) $response, true);
+                $message = $this->factory->create(Message::class, $response, true);
                 $this->messages->push($message);
 
                 $deferred->resolve($message);

--- a/src/Discord/Parts/Channel/Channel.php
+++ b/src/Discord/Parts/Channel/Channel.php
@@ -150,7 +150,10 @@ class Channel extends Part
 
         if (array_key_exists('recipients', $this->attributes)) {
             foreach ((array) $this->attributes['recipients'] as $recipient) {
-                $recipients->push($this->factory->create(User::class, (array) $recipient, true));
+                if (! $user = $this->discord->users->get('id', $receipient->id)) {
+                    $user = $this->factory->create(User::class, (array) $recipient, true);
+                }
+                $receipients->push($user);
             }
         }
 
@@ -192,11 +195,13 @@ class Channel extends Part
         $deferred = new Deferred();
 
         $this->http->get($this->replaceWithVariables('channels/:id/pins'))->then(
-            function ($response) use ($deferred) {
+            function ($responses) use ($deferred) {
                 $messages = new Collection();
 
-                foreach ($response as $message) {
-                    $message = $this->factory->create(Message::class, (array) $message, true);
+                foreach ($responses as $response) {
+                    if (! $message = $this->messages->get('id', $response->id)) {
+                        $message = $this->factory->create(Message::class, (array) $response, true);
+                    }
                     $messages->push($message);
                 }
 
@@ -343,7 +348,7 @@ class Channel extends Part
      *
      * @return \React\Promise\Promise
      */
-    public function muteMember($member)
+    public function muteMember($member): PromiseInterface
     {
         $deferred = new Deferred();
 
@@ -363,8 +368,8 @@ class Channel extends Part
                 'mute' => true,
             ]
         )->then(
-            \React\Partial\bind([$deferred, 'resolve']),
-            \React\Partial\bind([$deferred, 'reject'])
+            Bind([$deferred, 'resolve']),
+            Bind([$deferred, 'reject'])
         );
 
         // At the moment we are unable to check if the member
@@ -380,7 +385,7 @@ class Channel extends Part
      *
      * @return \React\Promise\Promise
      */
-    public function unmuteMember($member)
+    public function unmuteMember($member): PromiseInterface
     {
         $deferred = new Deferred();
 
@@ -400,8 +405,8 @@ class Channel extends Part
                 'mute' => false,
             ]
         )->then(
-            \React\Partial\bind([$deferred, 'resolve']),
-            \React\Partial\bind([$deferred, 'reject'])
+            Bind([$deferred, 'resolve']),
+            Bind([$deferred, 'reject'])
         );
 
         // At the moment we are unable to check if the member
@@ -463,7 +468,9 @@ class Channel extends Part
             $deferred->resolve();
         } elseif ($count == 1 || $this->is_private) {
             foreach ($messages as $message) {
-                if ($message instanceof Message) {
+                if ($message instanceof Message ||
+                    $message = $this->messages->get('id', $message)
+                ) {
                     $message->delete();
                 } else {
                     $this->http->delete("channels/{$this->id}/messages/{$message}")->then(
@@ -483,15 +490,18 @@ class Channel extends Part
                 }
             }
 
-            $this->http->post(
-                "channels/{$this->id}/messages/bulk_delete",
-                [
-                    'messages' => $messageID,
-                ]
-            )->then(
-                Bind([$deferred, 'resolve']),
-                Bind([$deferred, 'reject'])
-            );
+            while (!empty($messageID)) {
+                $this->http->post(
+                    "channels/{$this->id}/messages/bulk_delete",
+                    [
+                        'messages' => array_slice($messageID, 0, 100)
+                    ]
+                )->then(
+                    Bind([$deferred, 'resolve']),
+                    Bind([$deferred, 'reject'])
+                );
+                $messageID = array_slice($messageID, 100);
+            }
         }
 
         return $deferred->promise();
@@ -537,11 +547,13 @@ class Channel extends Part
         }
 
         $this->http->get($url, null, [], $options['cache'] ? null : 0)->then(
-            function ($response) use ($deferred) {
+            function ($responses) use ($deferred) {
                 $messages = new Collection();
 
-                foreach ($response as $message) {
-                    $message = $this->factory->create(Message::class, (array) $message, true);
+                foreach ($responses as $response) {
+                    if (! $message = $this->messages->get('id', $response->id)) {
+                        $message = $this->factory->create(Message::class, (array) $response, true);
+                    }
                     $messages->push($message);
                 }
 
@@ -923,7 +935,7 @@ class Channel extends Part
      */
     public function allowVoice()
     {
-        return ($this->type == self::TYPE_VOICE);
+        return in_array($this->type, [self::TYPE_VOICE]);
     }
 
     /**

--- a/src/Discord/Parts/Channel/Message.php
+++ b/src/Discord/Parts/Channel/Message.php
@@ -211,9 +211,7 @@ class Message extends Part
      */
     protected function getChannelAttribute(): Channel
     {
-        if ($channel = $this->discord->getChannel($this->channel_id) ||
-            $channel = $this->discord->private_channels->get('id', $this->channel_id)
-        ) {
+        if ($channel = $this->discord->getChannel($this->channel_id)) {
             return $channel;
         }
 

--- a/src/Discord/Parts/Channel/Message.php
+++ b/src/Discord/Parts/Channel/Message.php
@@ -175,7 +175,7 @@ class Message extends Part
         if (isset($this->attributes['mention_channels'])) {
             foreach ($this->attributes['mention_channels'] as $mention_channel) {
                 if (! $channel = $this->discord->getChannel($mention_channel->id)) {
-                    $channel = $this->factory->create(Channel::class, (array) $channel, true);
+                    $channel = $this->factory->create(Channel::class, $channel, true);
                 }
                 $collection->push($channel);
             }
@@ -196,7 +196,7 @@ class Message extends Part
 
         if (isset($this->attributes['reactions'])) {
             foreach ($this->attributes['reactions'] as $reaction) {
-                $collection->push($this->factory->create(Reaction::class, (array) $reaction, true));
+                $collection->push($this->factory->create(Reaction::class, $reaction, true));
             }
         }
 
@@ -211,7 +211,9 @@ class Message extends Part
      */
     protected function getChannelAttribute(): Channel
     {
-        if ($channel = $this->discord->getChannel($this->channel_id)) {
+        if ($channel = $this->discord->getChannel($this->channel_id) ||
+            $channel = $this->discord->private_channels->get('id', $this->channel_id)
+        ) {
             return $channel;
         }
 
@@ -253,7 +255,7 @@ class Message extends Part
 
         foreach ($this->attributes['mentions'] as $mention) {
             if (! $user = $this->discord->users->get('id', $mention->id)) {
-                $user = $this->factory->create(User::class, (array) $mention, true);
+                $user = $this->factory->create(User::class, $mention, true);
             }
             $users->push($user);
         }
@@ -276,7 +278,7 @@ class Message extends Part
             return $author;
         }
 
-        return $this->factory->create(User::class, (array) $this->attributes['author'], true);
+        return $this->factory->create(User::class, $this->attributes['author'], true);
     }
 
     /**
@@ -290,7 +292,7 @@ class Message extends Part
         $embeds = new Collection([], null);
 
         foreach ($this->attributes['embeds'] as $embed) {
-            $embeds->push($this->factory->create(Embed::class, (array) $embed, true));
+            $embeds->push($this->factory->create(Embed::class, $embed, true));
         }
 
         return $embeds;

--- a/src/Discord/Parts/Embed/Embed.php
+++ b/src/Discord/Parts/Embed/Embed.php
@@ -120,7 +120,7 @@ class Embed extends Part
 
         foreach ($this->attributes['fields'] as $field) {
             if (! ($field instanceof Field)) {
-                $field = $this->factory->create(Field::class, (array) $field, true);
+                $field = $this->factory->create(Field::class, $field, true);
             }
 
             $fields->push($field);
@@ -173,7 +173,7 @@ class Embed extends Part
     private function attributeHelper($key, $class)
     {
         if (! array_key_exists($key, $this->attributes)) {
-            return $this->factory->create($class, []);
+            return $this->factory->create($class);
         }
 
         if ($this->attributes[$key] instanceof $class) {

--- a/src/Discord/Parts/Guild/Guild.php
+++ b/src/Discord/Parts/Guild/Guild.php
@@ -170,7 +170,7 @@ class Guild extends Part
                 $invites = new Collection();
 
                 foreach ($response as $invite) {
-                    $invite = $this->factory->create(Invite::class, (array) $invite, true);
+                    $invite = $this->factory->create(Invite::class, $invite, true);
                     $invites->push($invite);
                 }
 

--- a/src/Discord/Parts/Guild/Invite.php
+++ b/src/Discord/Parts/Guild/Invite.php
@@ -108,7 +108,7 @@ class Invite extends Part
      */
     protected function getGuildAttribute(): Part
     {
-        return $this->factory->create(Guild::class, (array) $this->attributes['guild'], true);
+        return $this->factory->create(Guild::class, $this->attributes['guild'], true);
     }
 
     /**
@@ -119,7 +119,7 @@ class Invite extends Part
      */
     protected function getChannelAttribute(): Part
     {
-        return $this->factory->create(Channel::class, (array) $this->attributes['channel'], true);
+        return $this->factory->create(Channel::class, $this->attributes['channel'], true);
     }
 
     /**
@@ -140,7 +140,7 @@ class Invite extends Part
      */
     protected function getInviterAttribute(): Part
     {
-        return $this->factory->create(User::class, (array) $this->attributes['inviter'], true);
+        return $this->factory->create(User::class, $this->attributes['inviter'], true);
     }
 
     /**

--- a/src/Discord/Parts/User/Activity.php
+++ b/src/Discord/Parts/User/Activity.php
@@ -89,7 +89,7 @@ class Activity extends Part
     protected function getEmojiAttribute(): ?Emoji
     {
         if (isset($this->attributes['emoji'])) {
-            return $this->factory->create(Emoji::class, (array) $this->attributes['emoji'], true);
+            return $this->factory->create(Emoji::class, $this->attributes['emoji'], true);
         }
 
         return null;

--- a/src/Discord/Parts/User/Member.php
+++ b/src/Discord/Parts/User/Member.php
@@ -288,7 +288,7 @@ class Member extends Part
             $this->attributes['game'] = [];
         }
 
-        return $this->factory->create(Activity::class, (array) $this->attributes['game'], true);
+        return $this->factory->create(Activity::class, $this->attributes['game'], true);
     }
 
     /**
@@ -306,7 +306,7 @@ class Member extends Part
         }
 
         foreach ($this->attributes['activities'] as $activity) {
-            $activities->push($this->factory->create(Activity::class, (array) $activity, true));
+            $activities->push($this->factory->create(Activity::class, $activity, true));
         }
 
         return $activities;
@@ -385,7 +385,7 @@ class Member extends Part
             }
         } else {
             foreach ($this->attributes['roles'] as $role) {
-                $roles->push($this->factory->create(Role::class, (array) $role, true));
+                $roles->push($this->factory->create(Role::class, $role, true));
             }
         }
 

--- a/src/Discord/Parts/User/User.php
+++ b/src/Discord/Parts/User/User.php
@@ -75,7 +75,7 @@ class User extends Part
             $deferred->resolve($channel);
         } else {
             $this->http->post('users/@me/channels', ['recipient_id' => $this->id])->then(function ($response) use ($deferred) {
-                $channel = $this->factory->create(Channel::class, (array) $response, true);
+                $channel = $this->factory->create(Channel::class, $response, true);
                 $this->discord->private_channels->push($channel);
 
                 $deferred->resolve($channel);

--- a/src/Discord/Parts/WebSockets/PresenceUpdate.php
+++ b/src/Discord/Parts/WebSockets/PresenceUpdate.php
@@ -66,7 +66,7 @@ class PresenceUpdate extends Part
             return $user;
         }
 
-        return $this->factory->create(User::class, (array) $this->attributes['user'], true);
+        return $this->factory->create(User::class, $this->attributes['user'], true);
     }
 
     /**
@@ -110,7 +110,7 @@ class PresenceUpdate extends Part
             return null;
         }
 
-        return $this->factory->create(Activity::class, (array) $this->attributes['game'], true);
+        return $this->factory->create(Activity::class, $this->attributes['game'], true);
     }
 
     /**

--- a/src/Discord/Repository/AbstractRepository.php
+++ b/src/Discord/Repository/AbstractRepository.php
@@ -285,7 +285,7 @@ abstract class AbstractRepository extends Collection
                 str_replace(':id', $id, $this->endpoints['get'])
             )
         )->then(function ($response) use ($deferred) {
-            $part = $this->factory->create($this->class, (array) $response, true);
+            $part = $this->factory->create($this->class, $response, true);
 
             $deferred->resolve($part);
         }, function ($e) use ($deferred) {

--- a/src/Discord/WebSockets/Events/ChannelCreate.php
+++ b/src/Discord/WebSockets/Events/ChannelCreate.php
@@ -22,7 +22,7 @@ class ChannelCreate extends Event
      */
     public function handle(Deferred &$deferred, $data): void
     {
-        $channel = $this->factory->create(Channel::class, (array) $data, true);
+        $channel = $this->factory->create(Channel::class, $data, true);
 
         if (isset($data->attributes['recipients'])) {
             $this->discord->private_channels->push($channel);

--- a/src/Discord/WebSockets/Events/ChannelDelete.php
+++ b/src/Discord/WebSockets/Events/ChannelDelete.php
@@ -22,7 +22,7 @@ class ChannelDelete extends Event
      */
     public function handle(Deferred &$deferred, $data): void
     {
-        $channel = $this->factory->create(Channel::class, (array) $data);
+        $channel = $this->factory->create(Channel::class, $data);
 
         if ($guild = $channel->guild) {
             $guild->channels->pull($channel->id);

--- a/src/Discord/WebSockets/Events/ChannelUpdate.php
+++ b/src/Discord/WebSockets/Events/ChannelUpdate.php
@@ -22,7 +22,7 @@ class ChannelUpdate extends Event
      */
     public function handle(Deferred &$deferred, $data): void
     {
-        $channel = $this->factory->create(Channel::class, (array) $data, true);
+        $channel = $this->factory->create(Channel::class, $data, true);
 
         if ($channel->is_private) {
             $old = $this->discord->private_channels->get('id', $channel->id);

--- a/src/Discord/WebSockets/Events/GuildBanAdd.php
+++ b/src/Discord/WebSockets/Events/GuildBanAdd.php
@@ -22,7 +22,7 @@ class GuildBanAdd extends Event
      */
     public function handle(Deferred &$deferred, $data): void
     {
-        $ban = $this->factory->create(Ban::class, (array) $data, true);
+        $ban = $this->factory->create(Ban::class, $data, true);
 
         if ($guild = $ban->guild) {
             $guild->bans->push($ban);

--- a/src/Discord/WebSockets/Events/GuildBanRemove.php
+++ b/src/Discord/WebSockets/Events/GuildBanRemove.php
@@ -22,7 +22,7 @@ class GuildBanRemove extends Event
      */
     public function handle(Deferred &$deferred, $data): void
     {
-        $ban = $this->factory->create(Ban::class, (array) $data, true);
+        $ban = $this->factory->create(Ban::class, $data, true);
 
         if ($guild = $ban->guild) {
             $guild->bans->pull($ban->user->id);

--- a/src/Discord/WebSockets/Events/GuildCreate.php
+++ b/src/Discord/WebSockets/Events/GuildCreate.php
@@ -55,7 +55,7 @@ class GuildCreate extends Event
             $member = (array) $member;
             $member['guild_id'] = $data->id;
 
-            if (! $userPart = $this->discord->users->get('id', $member['user']->id)) {
+            if (! $this->discord->users->has($member['user']->id)) {
                 $userPart = $this->factory->create(User::class, $member['user'], true);
                 $this->discord->users->offsetSet($userPart->id, $userPart);
             }

--- a/src/Discord/WebSockets/Events/GuildCreate.php
+++ b/src/Discord/WebSockets/Events/GuildCreate.php
@@ -34,11 +34,11 @@ class GuildCreate extends Event
             return $deferred->promise();
         }
 
-        $guildPart = $this->factory->create(Guild::class, (array) $data, true);
+        $guildPart = $this->factory->create(Guild::class, $data, true);
         foreach ($data->roles as $role) {
             $role = (array) $role;
             $role['guild_id'] = $guildPart->id;
-            $rolePart = $this->factory->create(Role::class, (array) $role, true);
+            $rolePart = $this->factory->create(Role::class, $role, true);
 
             $guildPart->roles->offsetSet($rolePart->id, $rolePart);
         }
@@ -46,7 +46,7 @@ class GuildCreate extends Event
         foreach ($data->channels as $channel) {
             $channel = (array) $channel;
             $channel['guild_id'] = $data->id;
-            $channelPart = $this->factory->create(Channel::class, (array) $channel, true);
+            $channelPart = $this->factory->create(Channel::class, $channel, true);
 
             $guildPart->channels->offsetSet($channelPart->id, $channelPart);
         }
@@ -54,10 +54,13 @@ class GuildCreate extends Event
         foreach ($data->members as $member) {
             $member = (array) $member;
             $member['guild_id'] = $data->id;
-            $memberPart = $this->factory->create(Member::class, (array) $member, true);
-            $userPart = $this->factory->create(User::class, (array) $member['user'], true);
 
-            $this->discord->users->offsetSet($userPart->id, $userPart);
+            if (! $userPart = $this->discord->users->get('id', $member['user']->id)) {
+                $userPart = $this->factory->create(User::class, $member['user'], true);
+                $this->discord->users->offsetSet($userPart->id, $userPart);
+            }
+
+            $memberPart = $this->factory->create(Member::class, $member, true);
             $guildPart->members->offsetSet($memberPart->id, $memberPart);
         }
 
@@ -70,7 +73,7 @@ class GuildCreate extends Event
 
         foreach ($data->voice_states as $state) {
             if ($channel = $guildPart->channels->offsetGet($state->channel_id)) {
-                $stateUpdate = $this->factory->create(VoiceStateUpdatePart::class, (array) $state, true);
+                $stateUpdate = $this->factory->create(VoiceStateUpdatePart::class, $state, true);
 
                 $channel->members->offsetSet($stateUpdate->user_id, $stateUpdate);
                 $guildPart->channels->offsetSet($channel->id, $channel);

--- a/src/Discord/WebSockets/Events/GuildDelete.php
+++ b/src/Discord/WebSockets/Events/GuildDelete.php
@@ -22,7 +22,7 @@ class GuildDelete extends Event
      */
     public function handle(Deferred &$deferred, $data): void
     {
-        $guild = $this->factory->create(Guild::class, (array) $data, true);
+        $guild = $this->factory->create(Guild::class, $data, true);
 
         $this->discord->guilds->pull($guild->id);
 

--- a/src/Discord/WebSockets/Events/GuildMemberAdd.php
+++ b/src/Discord/WebSockets/Events/GuildMemberAdd.php
@@ -22,7 +22,7 @@ class GuildMemberAdd extends Event
      */
     public function handle(Deferred &$deferred, $data): void
     {
-        $member = $this->factory->create(Member::class, (array) $data, true);
+        $member = $this->factory->create(Member::class, $data, true);
 
         if ($guild = $this->discord->guilds->get('id', $member->guild_id)) {
             $guild->members->push($member);

--- a/src/Discord/WebSockets/Events/GuildMemberRemove.php
+++ b/src/Discord/WebSockets/Events/GuildMemberRemove.php
@@ -22,7 +22,7 @@ class GuildMemberRemove extends Event
      */
     public function handle(Deferred &$deferred, $data): void
     {
-        $member = $this->factory->create(Member::class, (array) $data, true);
+        $member = $this->factory->create(Member::class, $data, true);
 
         if ($guild = $this->discord->guilds->get('id', $member->guild_id)) {
             $guild->members->pull($member->user->id);

--- a/src/Discord/WebSockets/Events/GuildMemberUpdate.php
+++ b/src/Discord/WebSockets/Events/GuildMemberUpdate.php
@@ -22,7 +22,7 @@ class GuildMemberUpdate extends Event
      */
     public function handle(Deferred &$deferred, $data): void
     {
-        $memberPart = $this->factory->create(Member::class, (array) $data, true);
+        $memberPart = $this->factory->create(Member::class, $data, true);
         $old = null;
 
         if ($guild = $this->discord->guilds->get('id', $memberPart->guild_id)) {

--- a/src/Discord/WebSockets/Events/GuildRoleCreate.php
+++ b/src/Discord/WebSockets/Events/GuildRoleCreate.php
@@ -25,7 +25,7 @@ class GuildRoleCreate extends Event
         $adata = (array) $data->role;
         $adata['guild_id'] = $data->guild_id;
 
-        $rolePart = $this->factory->create(Role::class, (array) $adata, true);
+        $rolePart = $this->factory->create(Role::class, $adata, true);
 
         if ($guild = $this->discord->guilds->get('id', $rolePart->guild_id)) {
             $guild->roles->push($rolePart);

--- a/src/Discord/WebSockets/Events/GuildRoleUpdate.php
+++ b/src/Discord/WebSockets/Events/GuildRoleUpdate.php
@@ -25,7 +25,7 @@ class GuildRoleUpdate extends Event
         $adata = (array) $data->role;
         $adata['guild_id'] = $data->guild_id;
 
-        $rolePart = $this->factory->create(Role::class, (array) $adata, true);
+        $rolePart = $this->factory->create(Role::class, $adata, true);
 
         if ($guild = $this->discord->guilds->get('id', $rolePart->guild_id)) {
             $old = $guild->roles->get('id', $rolePart->id);

--- a/src/Discord/WebSockets/Events/GuildUpdate.php
+++ b/src/Discord/WebSockets/Events/GuildUpdate.php
@@ -32,12 +32,12 @@ class GuildUpdate extends Event
         /**
          * @var $guildPart Guild
          */
-        $guildPart = $this->factory->create(Guild::class, (array) $data, true);
+        $guildPart = $this->factory->create(Guild::class, $data, true);
 
         foreach ($data->roles as $role) {
             $role = (array) $role;
             $role['guild_id'] = $guildPart->id;
-            $rolePart = $this->factory->create(Role::class, (array) $role, true);
+            $rolePart = $this->factory->create(Role::class, $role, true);
 
             $guildPart->roles->push($rolePart);
         }

--- a/src/Discord/WebSockets/Events/InviteCreate.php
+++ b/src/Discord/WebSockets/Events/InviteCreate.php
@@ -22,7 +22,7 @@ class InviteCreate extends Event
      */
     public function handle(Deferred &$deferred, $data): void
     {
-        $invite = $this->factory->create(Invite::class, (array) $data, true);
+        $invite = $this->factory->create(Invite::class, $data, true);
 
         $deferred->resolve($invite);
     }

--- a/src/Discord/WebSockets/Events/MessageCreate.php
+++ b/src/Discord/WebSockets/Events/MessageCreate.php
@@ -22,7 +22,7 @@ class MessageCreate extends Event
      */
     public function handle(Deferred &$deferred, $data): void
     {
-        $message = $this->factory->create(Message::class, (array) $data, true);
+        $message = $this->factory->create(Message::class, $data, true);
 
         if ($this->discord->options['storeMessages']) {
             if ($channel = $message->channel) {

--- a/src/Discord/WebSockets/Events/MessageReactionAdd.php
+++ b/src/Discord/WebSockets/Events/MessageReactionAdd.php
@@ -22,7 +22,7 @@ class MessageReactionAdd extends Event
      */
     public function handle(Deferred &$deferred, $data): void
     {
-        $reaction = $this->factory->create(MessageReaction::class, (array) $data, true);
+        $reaction = $this->factory->create(MessageReaction::class, $data, true);
         $deferred->resolve($reaction);
     }
 }

--- a/src/Discord/WebSockets/Events/MessageReactionRemove.php
+++ b/src/Discord/WebSockets/Events/MessageReactionRemove.php
@@ -22,7 +22,7 @@ class MessageReactionRemove extends Event
      */
     public function handle(Deferred &$deferred, $data): void
     {
-        $reaction = $this->factory->create(MessageReaction::class, (array) $data, true);
+        $reaction = $this->factory->create(MessageReaction::class, $data, true);
         $deferred->resolve($reaction);
     }
 }

--- a/src/Discord/WebSockets/Events/MessageReactionRemoveAll.php
+++ b/src/Discord/WebSockets/Events/MessageReactionRemoveAll.php
@@ -22,7 +22,7 @@ class MessageReactionRemoveAll extends Event
      */
     public function handle(Deferred &$deferred, $data): void
     {
-        $reaction = $this->factory->create(MessageReaction::class, (array) $data, true);
+        $reaction = $this->factory->create(MessageReaction::class, $data, true);
         $deferred->resolve($reaction);
     }
 }

--- a/src/Discord/WebSockets/Events/MessageUpdate.php
+++ b/src/Discord/WebSockets/Events/MessageUpdate.php
@@ -22,7 +22,7 @@ class MessageUpdate extends Event
      */
     public function handle(Deferred &$deferred, $data): void
     {
-        $messagePart = $this->factory->create(Message::class, (array) $data, true);
+        $messagePart = $this->factory->create(Message::class, $data, true);
         $oldMessage = null;
 
         if ($channel = $messagePart->channel) {

--- a/src/Discord/WebSockets/Events/PresenceUpdate.php
+++ b/src/Discord/WebSockets/Events/PresenceUpdate.php
@@ -25,7 +25,7 @@ class PresenceUpdate extends Event
         /**
          * @var PresenceUpdatePart
          */
-        $presence = $this->factory->create(PresenceUpdatePart::class, (array) $data, true);
+        $presence = $this->factory->create(PresenceUpdatePart::class, $data, true);
 
         if ($guild = $presence->guild) {
             if ($member = $presence->member) {

--- a/src/Discord/WebSockets/Events/TypingStart.php
+++ b/src/Discord/WebSockets/Events/TypingStart.php
@@ -22,7 +22,7 @@ class TypingStart extends Event
      */
     public function handle(Deferred &$deferred, $data): void
     {
-        $typing = $this->factory->create(TypingStartPart::class, (array) $data, true);
+        $typing = $this->factory->create(TypingStartPart::class, $data, true);
 
         $deferred->resolve($typing);
     }

--- a/src/Discord/WebSockets/Events/VoiceServerUpdate.php
+++ b/src/Discord/WebSockets/Events/VoiceServerUpdate.php
@@ -22,7 +22,7 @@ class VoiceServerUpdate extends Event
      */
     public function handle(Deferred &$deferred, $data): void
     {
-        $part = $this->factory->create(VoiceServerUpdatePart::class, (array) $data, true);
+        $part = $this->factory->create(VoiceServerUpdatePart::class, $data, true);
 
         $deferred->resolve($part);
     }

--- a/src/Discord/WebSockets/Events/VoiceStateUpdate.php
+++ b/src/Discord/WebSockets/Events/VoiceStateUpdate.php
@@ -23,7 +23,7 @@ class VoiceStateUpdate extends Event
      */
     public function handle(Deferred &$deferred, $data): void
     {
-        $state = $this->factory->create(VoiceStateUpdatePart::class, (array) $data, true);
+        $state = $this->factory->create(VoiceStateUpdatePart::class, $data, true);
 
         if ($state->guild) {
             $guild = $state->guild;


### PR DESCRIPTION
- check if we not already have an object before creating a new one.
- changed allowVoice to be similar to allowText in case discord decides to expand.
- (un)muteMember updated.
- deleteMessages, enforce 100 message limit by sending it in batches when neccessary.
- other small cleanups.
- made on('ready') handler in __construct selfdestructing, and moved below disabledEvents (in case someone puts 'ready' in there to temp disable his own scripts.