### PR TITLE
Add DiscordPHP version info to default help menu

### DIFF
--- a/src/Discord/DiscordCommandClient.php
+++ b/src/Discord/DiscordCommandClient.php
@@ -384,7 +384,7 @@ class DiscordCommandClient extends Discord
             ->setDefaults([
                 'prefix' => '@mention ',
                 'name' => '<UsernamePlaceholder>',
-                'description' => 'A bot made with DiscordPHP.',
+                'description' => 'A bot made with DiscordPHP ' . self::VERSION . '.',
                 'defaultHelpCommand' => true,
                 'discordOptions' => [],
             ]);


### PR DESCRIPTION
Improve the default bot description by adding the DiscordPHP version
information (which is displayed in the help menu, if the description
is not customized).

It may or may not be desirable to put the version info somewhere in
the help menu that _cannot_ be customized.