### PR TITLE
getGuildAttribute can be null

### DIFF
--- a/src/Discord/Parts/WebSockets/PresenceUpdate.php
+++ b/src/Discord/Parts/WebSockets/PresenceUpdate.php
@@ -94,7 +94,7 @@ class PresenceUpdate extends Part
      *
      * @return Guild The guild that the user was in.
      */
-    protected function getGuildAttribute(): Guild
+    protected function getGuildAttribute(): ?Guild
     {
         return $this->discord->guilds->get('id', $this->guild_id);
     }


### PR DESCRIPTION
If the bot is removed from a guild then getGuildAttribute will return null on presence update