### PR TITLE
Guard against null beingconverted to an empty string

### DIFF
--- a/src/Discord/CommandClient/Command.php
+++ b/src/Discord/CommandClient/Command.php
@@ -138,7 +138,7 @@ class Command
             throw new \Exception("A sub-command with the name {$command} already exists.");
         }
 
-        if ($this->client->getCommandClientOptions()['caseInsensitiveCommands']) {
+        if ($command !== null && $this->client->getCommandClientOptions()['caseInsensitiveCommands']) {
             $command = strtolower($command);
         }
 
@@ -175,7 +175,7 @@ class Command
      */
     public function registerSubCommandAlias(string $alias, string $command): void
     {
-        if ($this->client->getCommandClientOptions()['caseInsensitiveCommands']) {
+        if ($alias !== null && $this->client->getCommandClientOptions()['caseInsensitiveCommands']) {
             $alias = strtolower($alias);
         }
 
@@ -209,7 +209,7 @@ class Command
     {
         $subCommand = array_shift($args);
 
-        if ($this->client->getCommandClientOptions()['caseInsensitiveCommands']) {
+        if ($subCommand !== null && $this->client->getCommandClientOptions()['caseInsensitiveCommands']) {
             $subCommand = strtolower($subCommand);
         }
 

--- a/src/Discord/DiscordCommandClient.php
+++ b/src/Discord/DiscordCommandClient.php
@@ -70,7 +70,7 @@ class DiscordCommandClient extends Discord
                     $args = str_getcsv($withoutPrefix, ' ');
                     $command = array_shift($args);
 
-                    if ($this->commandClientOptions['caseInsensitiveCommands']) {
+                    if ($command !== null && $this->commandClientOptions['caseInsensitiveCommands']) {
                         $command = strtolower($command);
                     }
 
@@ -217,7 +217,7 @@ class DiscordCommandClient extends Discord
      */
     public function registerCommand(string $command, $callable, array $options = []): Command
     {
-        if ($this->commandClientOptions['caseInsensitiveCommands']) {
+        if ($command !== null && $this->commandClientOptions['caseInsensitiveCommands']) {
             $command = strtolower($command);
         }
         if (array_key_exists($command, $this->commands)) {
@@ -228,7 +228,7 @@ class DiscordCommandClient extends Discord
         $this->commands[$command] = $commandInstance;
 
         foreach ($options['aliases'] as $alias) {
-            if ($this->commandClientOptions['caseInsensitiveCommands']) {
+            if ($alias !== null && $this->commandClientOptions['caseInsensitiveCommands']) {
                 $alias = strtolower($alias);
             }
             $this->registerAlias($alias, $command);


### PR DESCRIPTION
this causes build in help to fail for example.