### PR TITLE
Windows and SSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,14 @@ Before you start using this Library, you **need** to know how PHP works, you nee
 - `ext-json`
 - `ext-zlib`
 
+# Windows and SSL
+Unfortunately PHP on Windows does not have access to the Windows Certificate Store. This is an issue because TLS gets used and as such certificate verification gets applied (turning this off is **not** an option).
+
+You will notice this issue by your script exiting immediately after one loop turn without any errors. Unfortunately there is for some reason no error or exception.
+
+As such users of this library need to download a [Certificate Authority extract](https://curl.haxx.se/docs/caextract.html) from the cURL website.<br>
+The path to the caextract must be set in the [`php.ini`](https://secure.php.net/manual/en/openssl.configuration.php) for `openssl.cafile`.
+
 #### Recommended Extensions
 
 - The latest PHP version.


### PR DESCRIPTION
Updates the README to address issues with "connection to gateway.discord.gg:443 failed during TLS handshake: Unable to complete TLS handshake"